### PR TITLE
Use round instead of number_format

### DIFF
--- a/src/Dispatcher/ZmqDispatcher.php
+++ b/src/Dispatcher/ZmqDispatcher.php
@@ -105,7 +105,7 @@ class ZmqDispatcher implements DispatcherInterface
             'action'        => $message->getAction(),
             'started_at'    => date('c', $message->getRequestStartedTimestamp()), // ISO 8601
             'started_ms'    => $message->getRequestStartedTimestampInMilliseconds(),
-            'total_time'    => (float) number_format($message->getTotalTime(), 5),
+            'total_time'    => round($message->getTotalTime(), 5),
             'code'          => $message->getResponseCode(),
             'severity'      => $message->getSeverity(),
             'caller_id'     => $message->getCallerId(),


### PR DESCRIPTION
Otherwise it does not work with Non-english locales and will introduce thousands separators both of which logjam fails to interpret. Php's `round` also returns a `float` by definition, so I removed the typecast as well.
